### PR TITLE
Changed dart_webrtc deps

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,13 +2,16 @@ name: flutter_webrtc
 description: Flutter WebRTC plugin for iOS/Android/Destkop/Web, based on GoogleWebRTC.
 version: 0.12.1+hotfix.1
 homepage: https://github.com/cloudwebrtc/flutter-webrtc
+publish_to: none
 environment:
   sdk: '>=3.3.0 <4.0.0'
   flutter: '>=1.22.0'
 
 dependencies:
   collection: ^1.18.0
-  dart_webrtc: ^1.4.9
+  dart_webrtc:
+    git:
+      url: git@github.com:pam3ec555/dart-webrtc.git
   flutter:
     sdk: flutter
   path_provider: ^2.1.4


### PR DESCRIPTION
Изменил dart_webrtc потому что нужно было сделать изменения в исходниках. Можно было бы обойтись копипастой нескольких классов в эту репу, но как то много дублирования получится. В добавок тяжелее было бы поддерживать при обновлении dart_webrtc. А так, когда разрабы будут обновлять dart_webrtc, то мы просто будем подтягивать их изменения, точно также как ты делаешь это в этой репе

Добавил туда этот ПР https://github.com/pam3ec555/dart-webrtc/pull/1